### PR TITLE
chore: upgrade vite to v7.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "gh-pages": "^6.3.0",
         "typescript": "^5.9.2",
-        "vite": "^7.1.1"
+        "vite": "^7.1.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.1.tgz",
-      "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.2.tgz",
+      "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "devDependencies": {
     "gh-pages": "^6.3.0",
     "typescript": "^5.9.2",
-    "vite": "^7.1.1"
+    "vite": "^7.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- bump vite to 7.1.2

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b31eb891c832c9cc4ef126849ebd0